### PR TITLE
feat: add default issue and pr templates for Espressif organization

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/01-BUG-REPORT.yml
@@ -1,0 +1,143 @@
+---
+name: "\U0001F41B Bug Report"
+description: 'File a bug/issue'
+labels: ['Type: Bug']
+
+body:
+  - id: checklist
+    type: checkboxes
+    attributes:
+      label: 'Checklist'
+      description: 'Before submitting, please make sure you have completed the following:'
+      options:
+        - label: 'Checked the issue tracker for similar issues to ensure this is not a duplicate'
+          required: true
+        - label: 'Read the documentation to confirm the issue is not addressed there and your configuration is set correctly'
+          required: true
+        - label: "Tested with the latest version to ensure the issue hasn't been fixed"
+          required: true
+
+  - id: bug-frequency
+    type: dropdown
+    attributes:
+      label: 'How often does this bug occurs?'
+      multiple: false
+      options:
+        - 'always'
+        - 'often'
+        - 'rarely'
+        - 'only once'
+    validations:
+      required: true
+
+  - id: expected-behavior
+    type: textarea
+    attributes:
+      label: 'Expected behavior'
+      description: 'A clear and concise description of what you expected to happen.'
+      placeholder: 'I expected it to...'
+    validations:
+      required: true
+
+  - id: actual-behavior
+    type: textarea
+    attributes:
+      label: 'Actual behavior (suspected bug)'
+      description: 'Please describe the actual behavior. If applicable, add screenshots to help explain your problem.'
+      placeholder: 'Instead, it...'
+    validations:
+      required: true
+
+  - id: error-logs
+    type: textarea
+    attributes:
+      label: 'Error logs or terminal output'
+      placeholder: 'Paste error logs or terminal output here...'
+      render: 'shell'
+    validations:
+      required: false
+
+  - id: steps-to-reproduce
+    type: textarea
+    attributes:
+      label: 'Steps to reproduce the behavior'
+      description: 'How do you trigger this bug?'
+      placeholder: |
+        1. Set the environment variable '...'
+        2. Install package '...'
+        3. Run command '...'
+        4. See error
+        ...
+    validations:
+      required: true
+
+  - id: release-version
+    type: input
+    attributes:
+      label: 'Project release version'
+      description: 'On which release version of our project does this issue occur?'
+      placeholder: 'e.g., v1.4.0, latest, unreleased master'
+    validations:
+      required: true
+
+  - id: os-architecture
+    type: dropdown
+    attributes:
+      label: 'System architecture'
+      description: "Select your system's CPU architecture."
+      multiple: false
+      options:
+        - 'Intel/AMD 64-bit (modern PC, older Mac)'
+        - 'ARM 64-bit (Apple M1/M2, Raspberry Pi 4/5)'
+        - 'ARM 32-bit (Raspberry Pi 32-bit)'
+        - 'other (details in Additional context)'
+    validations:
+      required: true
+
+  - id: os-type
+    type: dropdown
+    attributes:
+      label: 'Operating system'
+      description: 'Select the operating system your system is running.'
+      multiple: false
+      options:
+        - 'Linux'
+        - 'Windows'
+        - 'MacOS'
+    validations:
+      required: true
+
+  - id: os-version
+    type: input
+    attributes:
+      label: 'Operating system version'
+      description: 'Specify the detailed version of your operating system.'
+      placeholder: 'e.g., Windows 10, Ubuntu 20.04, Monterey'
+    validations:
+      required: true
+
+  - id: shell
+    type: dropdown
+    attributes:
+      label: 'Shell'
+      description: 'Select which command-line shell you are using.'
+      multiple: false
+      options:
+        - 'ZSH'
+        - 'Bash'
+        - 'sh'
+        - 'Fish'
+        - 'PowerShell'
+        - 'CMD'
+        - 'other (details in Additional context)'
+    validations:
+      required: true
+
+  - id: additional-context
+    type: textarea
+    attributes:
+      label: 'Additional context'
+      description: 'Add any extra details or context that might help in understanding the issue.'
+      placeholder: 'Add any other context here...'
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/02-FEATURE-REQUEST.yml
@@ -1,0 +1,52 @@
+name: "\U0001F4A1 Feature Request"
+description: "Suggest a new feature or enhancement"
+labels: ["Type: Feature Request"]
+body:
+  - id: checklist
+    type: checkboxes
+    attributes:
+      label: "Checklist"
+      description: "Before submitting, please make sure you have completed the following:"
+      options:
+        - label: "Checked the issue tracker for similar issues to ensure this is not a duplicate."
+          required: true
+        - label: "Described the feature in detail and justified the reason for the request."
+          required: true
+        - label: "Provided specific use cases and examples."
+          required: true
+
+  - id: feature-description
+    type: textarea
+    attributes:
+      label: "Feature description"
+      description: "Please provide a detailed description of the feature you are requesting."
+      placeholder: "Describe the feature in detail..."
+    validations:
+      required: true
+
+  - id: use-cases
+    type: textarea
+    attributes:
+      label: "Use cases"
+      description: "Please provide specific use cases where this feature would be useful."
+      placeholder: "Describe use cases..."
+    validations:
+      required: true
+
+  - id: alternatives
+    type: textarea
+    attributes:
+      label: "Alternatives"
+      description: "Please describe any alternative solutions or features you've considered."
+      placeholder: "Describe alternatives..."
+    validations:
+      required: false
+
+  - id: additional-context
+    type: textarea
+    attributes:
+      label: "Additional context"
+      description: "Add any extra details or context that might help in understanding your request."
+      placeholder: "Add any other context here..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-OTHER.yml
+++ b/.github/ISSUE_TEMPLATE/03-OTHER.yml
@@ -1,0 +1,25 @@
+name: "\U0001F4AD Other Issue or Suggestion"
+description: "Share any suggestions or issues that aren't related to bugs or feature requests."
+labels: ["Type: Question"]
+body:
+  - id: checklist
+    type: checkboxes
+    attributes:
+      label: "Checklist"
+      description: "Before submitting, please make sure you have completed the following:"
+      options:
+        - label: "Checked the issue tracker for similar issues to ensure this is not a duplicate."
+          required: true
+        - label: "Provided a clear description of your suggestion."
+          required: true
+        - label: "Included any relevant context or examples."
+          required: true
+
+  - id: issue-description
+    type: textarea
+    attributes:
+      label: "Issue or Suggestion Description"
+      description: "Please provide a detailed description of the issue or suggestion."
+      placeholder: "Describe the issue or suggestion in detail..."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+---
+blank_issues_enabled: false
+
+contact_links:
+  - name: "Espressif GitHub"
+    url: "https://github.com/espressif"
+    about: "Espressif's GitHub repositories"
+
+  - name: "Espressif Homepage"
+    url: "https://www.espressif.com"
+    about: "About the company"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+<!--
+- Read and understand the project style guidelines (`CONTRIBUTION.md`).
+- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
+- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
+- Include screenshots for any CLI or UI changes.
+- Keep PRs as small as possible; large PRs are difficult to review.
+-->
+
+## Description
+
+<!--
+- Please include a summary of the changes and the related issue.
+- Also include the motivation (why this change) and context.
+-->
+
+<!-- 
+- If you want to insert images (screenshots, diagrams, etc.), please format them:
+    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
+    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
+-->
+
+## Related
+
+<!--
+- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
+- Mention any other PRs related to this one.
+- If there is related documentation, add the link here.
+- If there is a public chat where changes in this PR were initiated, you can include the link here.
+-->
+
+## Testing
+
+<!--
+- Explain how you tested your change or new feature.
+- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
+-->
+
+---
+
+## Checklist
+
+Before submitting a Pull Request, please ensure the following:
+
+- [ ] 🚨 This PR does not introduce breaking changes.
+- [ ] All CI checks (GH Actions) pass.
+- [ ] Documentation is updated as needed.
+- [ ] Tests are updated or added as necessary.
+- [ ] Code is well-commented, especially in complex areas.
+- [ ] Git history is clean — commits are squashed to the minimum necessary.


### PR DESCRIPTION
This PR will **automatically add default issue templates and a default Pull Request template to all Espressif GitHub repositories**.

- ☘️ Repositories that have their own templates [**will not be affected by this; the local (repo-specific) template takes precedence**](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#about-default-community-health-files).
- Newly created repositories will automatically have access to these templates.
- The **names of local templates don't need to match the org-level templates**. The **presence of any** local templates in the repository will override the use of **all** organization-level templates. 

#### Templates in this PR
- Added three default issue templates: `bugfix`, `feature`, and `other` - interactive forms (YAML syntax).
- Added a configuration file for issue templates (`.github/ISSUE_TEMPLATE/config.yml`) - forbids using blank issue templates (free-form issues) + additional links.
- Added a default PR template with useful comments for developers and contributors (Markdown).
- I crafted issue template files based on GitHub standard templates, our IDF templates and typical issues in Espressif GitHub projects - tried to be as generic as possible while making the template sensible and useful for most projects.
- The comments + checklist in the PR template are based on common mistakes that contributors make and typical things they often forget to do.

#### Reasoning / Why this
Right now, many Espressif projects appear as if they weren't made by people from the same organization — each repo uses a slightly different setup. This looks unprofessional and is confusing for contributors working across multiple repos. 
With new repositories, their admins have to set up these templates manually (without defined standard) which is very tedious.

This repo ( https://github.com/espressif/.github/ ) is a great place for centralized templates like this, because it can be managed/updated from a single place and still give repo admins freedom to customize if they need to.

---

## Tested 
- The same files as in this PR were pushed to my test organization’s `.github` repo: https://github.com/tomassebestik-test-org/.github/tree/master/.github

Then, without any further changes:
- ✔️ [Example repo WITHOUT local templates](https://github.com/tomassebestik-test-org/testorg-useimage/issues/new/choose)
- ✔️ [Example repo WITH templates](https://github.com/tomassebestik-test-org/testorg-createimage/issues/new/choose) (copied local templates from `espressif/esptool`)
- ✔️ [Example repo created after templates were added](https://github.com/tomassebestik-test-org/new-repo-example-09-01-24/issues/new/choose)
