### PR TITLE
Add reusable workflows structure, pre-commit and danger

### DIFF
--- a/.github/workflows/reusable-dangerjs-github.yml
+++ b/.github/workflows/reusable-dangerjs-github.yml
@@ -1,0 +1,132 @@
+---
+# Reusable workflow in  "espressif/.github" repository (Organization level)
+name: DangerJS (PR style linter)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The pull request head reference'
+        required: true
+        type: string
+      rule-description:
+        description: 'Enable rule for PR Description'
+        required: false
+        type: string
+        default: 'true'
+      rule-commit-messages:
+        description: 'Enable rule for PR Lint Commit Messages'
+        required: false
+        type: string
+        default: 'true'
+      rule-size-lines:
+        description: 'Enable rule for PR Size (changed lines)'
+        required: false
+        type: string
+        default: 'true'
+      rule-source-branch:
+        description: 'Enable rule for PR Source branch name'
+        required: false
+        type: string
+        default: 'true'
+      rule-target-branch:
+        description: 'Enable rule for PR Target branch name'
+        required: false
+        type: string
+        default: 'true'
+      rule-max-commits:
+        description: 'Enable rule for PR Too Many Commits'
+        required: false
+        type: string
+        default: 'true'
+      commit-messages-types:
+        description: 'Allowed commit message "Type"s'
+        required: false
+        type: string
+        default: 'change,ci,docs,feat,fix,refactor,remove,revert,test'
+      commit-messages-max-body-line-length:
+        description: 'Max length for commit message "Body" line'
+        required: false
+        type: string
+        default: '100'
+      commit-messages-max-summary-length:
+        description: 'Max length for commit message "Summary"'
+        required: false
+        type: string
+        default: '72'
+      commit-messages-min-summary-length:
+        description: 'Min length for commit message "Summary"'
+        required: false
+        type: string
+        default: '20'
+      description-ignore-sections:
+        description: 'Sections of PR description to ignore when counting length'
+        required: false
+        type: string
+        default: 'related,release,breaking'
+      max-size-lines:
+        description: 'Max changed code lines in PR'
+        required: false
+        type: string
+        default: '1000'
+      max-commits-info:
+        description: 'Soft limit for maximum commits in PR'
+        required: false
+        type: string
+        default: '2'
+      max-commits-warn:
+        description: 'Hard limit for maximum commits in PR'
+        required: false
+        type: string
+        default: '5'
+      instructions-contributions-file:
+        description: 'Path to CONTRIBUTING.md or other instructions file'
+        required: false
+        type: string
+        default: ''
+      instructions-gitlab-mirror:
+        description: 'Enable GitLab mirror instructions'
+        required: false
+        type: string
+        default: 'false'
+      instructions-cla-link:
+        description: 'Link to CLA (Contributor License Agreement)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  pull-request-style-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: DangerJS pull request linter
+        uses: espressif/shared-github-dangerjs@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          rule-description: ${{ inputs.rule-description }}
+          rule-commit-messages: ${{ inputs.rule-commit-messages }}
+          rule-size-lines: ${{ inputs.rule-size-lines }}
+          rule-source-branch: ${{ inputs.rule-source-branch }}
+          rule-target-branch: ${{ inputs.rule-target-branch }}
+          rule-max-commits: ${{ inputs.rule-max-commits }}
+          commit-messages-types: ${{ inputs.commit-messages-types }}
+          commit-messages-max-body-line-length: ${{ inputs.commit-messages-max-body-line-length }}
+          commit-messages-max-summary-length: ${{ inputs.commit-messages-max-summary-length }}
+          commit-messages-min-summary-length: ${{ inputs.commit-messages-min-summary-length }}
+          description-ignore-sections: ${{ inputs.description-ignore-sections }}
+          max-size-lines: ${{ inputs.max-size-lines }}
+          max-commits-info: ${{ inputs.max-commits-info }}
+          max-commits-warn: ${{ inputs.max-commits-warn }}
+          instructions-contributions-file: ${{ inputs.instructions-contributions-file }}
+          instructions-gitlab-mirror: ${{ inputs.instructions-gitlab-mirror }}
+          instructions-cla-link: ${{ inputs.instructions-cla-link }}

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -1,0 +1,34 @@
+---
+# Reusable workflow in  "espressif/.github" repository (Organization level)
+name: Pre-commit (PR code changes)
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: 'The Python version to use in CI'
+        required: false
+        type: string
+        default: '3.9'
+      skip:
+        description: "The pre-commit hooks to skip in CI"
+        required: false
+        type: string
+        default: 'pip-compile'
+
+jobs:
+  check-pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: ${{ inputs.skip }} 

--- a/.github/workflows/workflows-instructions.md
+++ b/.github/workflows/workflows-instructions.md
@@ -1,0 +1,75 @@
+These are [GitHub reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) that can be called from any repository within the Espressif GitHub organization.
+
+ℹ️ Their **presence here does not mean they are automatically propagated or inherited across all Espressif organization GitHub repositories** (as with issue and pull request templates). These workflows **need to be explicitly called**. See the ["Calling from the target repository"](#calling-from-the-target-repository) section for details.
+
+---
+
+- [Reasoning](#reasoning)
+- [Calling from the target repository](#calling-from-the-target-repository)
+- [Custom Parameters and Configuration](#custom-parameters-and-configuration)
+- [Troubleshooting](#troubleshooting)
+
+## Reasoning
+
+Managing these workflows from a central place like this repository (`espressif/.github`) offers several advantages:
+
+- **Ease of Integration**: Simplifies the process for repository administrators—only a call statement is needed to integrate the workflow.
+- **Centralized Updates**: Quickly update the version of a GitHub workflow for all repositories that use it with a single change here.
+- **Consistent Permissions**: Ensure that action permissions are set correctly across all repositories.
+
+## Calling from the target repository
+
+In the target repository, e.g., `espressif/example-repo`, the following steps are required:
+
+1. Create a file at the usual location for GitHub Actions workflow YAML files, such as `.github/workflows/call-pre-commit.yml`.
+2. Add the following content to that file:
+
+```yaml
+# REPO: https://github.com/espressif/example-repo
+# FILE: .github/workflows/call-pre-commit.yml
+---
+name: Pre-commit (PR code changes)
+
+on:
+  pull_request:
+
+jobs:
+  call-pre-commit:
+  uses: espressif/.github/.github/workflows/reusable-pre-commit.yml@main
+```
+
+This will enable the reusable GitHub workflow in the target repository (`espressif/example-repo`).
+
+If the configuration ever changes in the `espressif/.github` repository (this repo), there is no need to make changes in every repository — it is propagated automatically. For example, if an external action version is updated (e.g., `uses: actions/setup-python@v4` to `uses: actions/setup-python@v5`), it would automatically apply to all repositories using this workflow.
+
+## Custom Parameters and Configuration
+
+The reusable workflow can be called with custom parameters, such as:
+
+```yaml
+# REPO: https://github.com/espressif/example-repo
+# FILE: .github/workflows/call-pre-commit.yml
+---
+name: Pre-commit checks
+
+on:
+  pull_request:
+
+jobs:
+  call-pre-commit:
+    uses: espressif/.github/.github/workflows/reusable-pre-commit.yml@main
+    with:
+      python-version: '3.12' # Optionally override the Python version
+      skip: 'codespell,mdformat' # Optionally skip specific pre-commit hooks in CI
+```
+
+This allows precise customization of the local action configuration without needing to delve into the full action YAML file.
+
+## Troubleshooting
+
+If the reusable workflow is not running in the target repository, check the following:
+
+- **Actions and Workflow Permissions**: Ensure that the target repository allows `Allow all actions and reusable workflows` (in repo `Settings -> Actions -> Actions permissions`).
+- **Correct Path to Reusable Workflow**: Double-check the path in the `uses:` directive. The correct format is `espressif/.github/.github/workflows/<WORKFLOW_FILE_NAME>.yml@main` (note the two `.github` segments in the path; the first refers to the .github repository, and the second refers to the .github directory within that repository).
+
+---


### PR DESCRIPTION
This PR creates the structure for using [GitHub reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) that can be called from any repository within the Espressif GitHub organization.

ℹ️ **Note**: Their presence here does not mean they are automatically propagated or inherited across all Espressif organization GitHub repositories (as with issue and pull request templates). These workflows **need to be explicitly called**. See the `.github/workflows/workflows-instructions.md` (part of this PR) for more details.

#### Reasoning / Why This
Managing these workflows from a central place like this repository (`espressif/.github`) offers several advantages:

- **Ease of Integration**: Simplifies the process for repository administrators—only a call statement is needed to integrate the workflow.
- **Centralized Updates**: Quickly update the version of a GitHub workflow for all repositories that use it with a single change here.
- **Consistent Permissions**: Ensure that action permissions are set correctly across all repositories.

#### Reusable Workflows in This PR
- [x] Configurable **pre-commit** reusable workflow
- [x] Configurable **dangerjs** reusable workflow
- [ ] Configurable **jira-sync** reusable workflows

---

## Tested 
Tested in my test GitHub organization:
- [test org `.github` repo - where reusable workflows are defined](https://github.com/tomassebestik-test-org/.github/tree/master/.github/workflows)
- [test org target repo - where reusable workflows are called - code](https://github.com/tomassebestik-test-org/new-repo-example-09-01-24/tree/master/.github/workflows)
- [test org target repo - where reusable workflows are called - action run](https://github.com/tomassebestik-test-org/new-repo-example-09-01-24/actions) ✔️ 
