### PR TITLE
feat(labels): add organization default issue Labels configurations

### DIFF
--- a/.github/default-labels/component-labels.yml
+++ b/.github/default-labels/component-labels.yml
@@ -1,0 +1,160 @@
+---
+# This is for now only list of standard Espressif issue/PR labels as a reference.
+# Config files can be combined and projects grouped. For example, all org projects
+#  will have set 'global-labels'+'jira-labels', then defined subset of projects also 'component-labels'
+
+# We plan to integrate it with GitHub action https://github.com/EndBug/label-sync
+#  and sync labels to org projects from one place. This needs to be tested first.
+
+# Properties explanation:
+#  name - The name of the label.
+#  color - The color of the label.
+#  description - [optional] The description of the label.
+#  aliases - [optional] An array containing the "aliases" of the label. If an existing label's name is an alias that label will be edited to match your config: this way you don't loose issues and PRs that have been labeled previously.
+
+
+# (List of components based on https://github.com/espressif/idf-extra-components)
+- name: 'Component: bdc_motor'
+  description: 'Component: bdc_motor'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: coap'
+  description: 'Component: coap'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: coremark'
+  description: 'Component: coremark'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: dhara'
+  description: 'Component: dhara'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: esp_delta_ota'
+  description: 'Component: esp_delta_ota'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: esp_driver_sccb'
+  description: 'Component: esp_driver_sccb'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: esp_encrypted_img'
+  description: 'Component: esp_encrypted_img'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: esp_jpeg'
+  description: 'Component: esp_jpeg'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: esp_serial_slave_link'
+  description: 'Component: esp_serial_slave_link'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: fmt'
+  description: 'Component: fmt'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: freetype'
+  description: 'Component: freetype'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: jsmn'
+  description: 'Component: jsmn'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: json_generator'
+  description: 'Component: json_generator'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: json_parser'
+  description: 'Component: json_parser'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: led_strip'
+  description: 'Component: led_strip'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: libsodium'
+  description: 'Component: libsodium'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: network_provisioning'
+  description: 'Component: network_provisioning'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: new request'
+  description: 'Component: new request'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: nghttp'
+  description: 'Component: nghttp'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: onewire_bus'
+  description: 'Component: onewire_bus'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: openCV'
+  description: 'Component: openCV'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: pcap'
+  description: 'Component: pcap'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: pid_ctrl'
+  description: 'Component: pid_ctrl'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: qrcode'
+  description: 'Component: qrcode'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: sh2lib'
+  description: 'Component: sh2lib'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: spi_nand_flash'
+  description: 'Component: spi_nand_flash'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: supertinycron'
+  description: 'Component: supertinycron'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: thorvg'
+  description: 'Component: thorvg'
+  color: '#caedfb'
+  aliases: []
+
+- name: 'Component: usb'
+  description: 'Component: usb'
+  color: '#caedfb'
+  aliases: []

--- a/.github/default-labels/global-labels.yml
+++ b/.github/default-labels/global-labels.yml
@@ -1,0 +1,134 @@
+---
+# This is for now only list of standard Espressif issue/PR labels as a reference.
+# Config files can be combined and projects grouped. For example, all org projects
+#  will have set 'global-labels', then defined subset of projects 'global-labels' + 'component-labels', etc ...
+
+# We plan to integrate it with GitHub action https://github.com/EndBug/label-sync
+#  and sync labels to org projects from one place. This needs to be tested first.
+
+# Properties explanation:
+#  name - The name of the label.
+#  color - The color of the label.
+#  description - [optional] The description of the label.
+#  aliases - [optional] An array containing the "aliases" of the label. If an existing label's name is an alias that label will be edited to match your config: this way you don't loose issues and PRs that have been labeled previously.
+
+# Issue types
+- name: 'Type: Bug'
+  description: 'Bug report'
+  color: '#ee0701'
+  aliases: ['bug']
+
+- name: 'Type: Feature Request'
+  description: 'Feature request'
+  color: '#84b6eb'
+  aliases: []
+
+- name: 'Type: Enhancement'
+  description: 'Issue related to project performance'
+  color: '#adecee'
+  aliases: ['enhancement']
+
+- name: 'Type: Question'
+  description: 'Further information is requested'
+  color: '#c1437a'
+  aliases: ['question']
+
+- name: 'Type: Infrastructure'
+  description: 'Issue related to project performance'
+  color: '#c5a251'
+  aliases: ['infrastructure']
+
+- name: 'Type: Doc'
+  description: 'Issue related to project documentation'
+  color: '#2076c4'
+  aliases: ['documentation']
+
+- name: 'Type: Performance'
+  description: 'Issue related to project performance'
+  color: '#fbca04'
+
+- name: 'Type: Dependencies'
+  description: 'Dependencies and version updates'
+  color: '#FE8547'
+  aliases: ['dependencies']
+
+- name: 'Type: Security'
+  description: 'Security updates'
+  color: '##D9AEC5'
+  aliases: []
+
+# Community labels
+- name: 'Help wanted'
+  description: 'Need some help with this one'
+  color: '#008672'
+  aliases: ['help wanted']
+
+- name: 'Good first issue'
+  description: 'Good for newcomers'
+  color: '#6960f6'
+  aliases: ['good first issue']
+
+- name: 'Invalid'
+  description: "This doesn't seem right"
+  color: '#e5e47a'
+  aliases: ['invalid']
+
+# JIRA Resolutions
+- name: 'Resolution: Cannot Reproduce'
+  description: 'Issue cannot be reproduced'
+  color: '#C2E0C6'
+
+- name: 'Resolution: Duplicate'
+  description: 'This issue or pull request already exists'
+  color: '#C2E0C6'
+  aliases: ['duplicate']
+
+- name: "Resolution: Won't Do"
+  description: 'This will not be worked on'
+  color: '#C2E0C6'
+  aliases: ['wontfix']
+
+- name: 'Resolution: Done'
+  description: 'Issue is done internally'
+  color: '#C2E0C6'
+
+- name: 'Resolution: NA'
+  description: 'Issue resolution is unavailable'
+  color: '#C2E0C6'
+
+# JIRA Work status
+- name: 'Status: In Progress'
+  description: 'Work is in progress'
+  color: '#1D76DB'
+
+- name: 'Status: Pending'
+  description: 'Blocked by some other factor'
+  color: '#fef2c0'
+
+- name: 'Status: Opened'
+  description: 'Issue is new, not started'
+  color: '#EDEDED'
+
+- name: 'Status: Done'
+  description: 'Issue is done internally'
+  color: '#0E8A16'
+
+- name: 'Status: Reviewing'
+  description: 'Issue is being reviewed'
+  color: '#1D76DB'
+
+- name: 'Status: Resolved'
+  description: 'Issue is done internally'
+  color: '#0E8A16'
+
+- name: 'Status: Cancelled'
+  description: 'Canceled in progress'
+  color: '#0E8A16'
+
+- name: 'Status: Awaiting Response'
+  description: 'Awaiting a response from the author'
+  color: '#FF1493'
+
+- name: 'Status: Selected for Development'
+  description: 'We will start soon'
+  color: '#ededed'


### PR DESCRIPTION
## Description

Defining standard organization labels, that we can distribute to Espressif projects

This is for now only list of standard Espressif issue/PR labels as a reference.

Config files can be combined and projects grouped. For example, all org projects will have set 'global-labels', then defined subset of projects 'global-labels' + 'component-labels', etc ...

## Next steps (TODO)
We plan to integrate it with GitHub action https://github.com/EndBug/label-sync and sync labels to org projects from one place, but **this needs to be tested** first.

## Related
- internal JIRA ticket: RDT-940
- internal [sharepoint Excel proposal](https://espressifsystems-my.sharepoint.com/:x:/g/personal/anastasiia_berezina_espressif_com/EetJoudzLuxCtE4XrFk3i-gB50WBNNsCoW4PnDCKd8PVBw?e=fQc8jF) by @anastasia-be 
