### PR TITLE
Add internal README.md with the purpose of this special repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# .github repository of Espressif GitHub organization
+
+1. This is an admin repository used for distributing common issue templates, labels, and workflows across the Espressif GitHub organization.
+
+2. The README in the `/profile` directory will appear on the organization's profile. [Edit Organization profile README](https://github.com/espressif/.github/edit/main/profile/README.md).
+
+Issues in this project are disabled.
+If you want to report an issue with an Espressif projects or products and you ended up here, please try to find the corresponding GitHub project where you can report your issue, such as:
+
+- [ESP-IDF project](https://github.com/espressif/esp-idf/issues)
+- [Arduino ESP32 project](https://github.com/espressif/arduino-esp32/issues)
+
+... or [many more](https://github.com/orgs/espressif/repositories) and report your issue there.


### PR DESCRIPTION
This PR adds an **internal README (NOT the one propagated to the public organizational profile)** document explaining the purpose of this special repository.

We have to disable Issues in this project, as people sometimes get confused about where to report general issues and end up reporting here.

## Related
- https://github.com/espressif/esp-idf/issues/15417

## Testing
In a test organization, I tried to make `<org>/.github` repo private, but this seems to hide the public profile (this is also described in [GitHub Docs](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile#adding-a-public-organization-profile-readme)):

#### Organization /.github repo private

<img width="500" alt="image" src="https://github.com/user-attachments/assets/18036299-9d9a-4ba6-8d4a-304c505ff1b0" />

#### Organization /.github repo public

<img width="500" alt="image" src="https://github.com/user-attachments/assets/de2fbee2-1ad6-4c26-b802-3e78c7bdea44" />